### PR TITLE
fix imports so they work in web

### DIFF
--- a/src/loadAzure.js
+++ b/src/loadAzure.js
@@ -1,11 +1,11 @@
+import { ComputerVisionClient } from '@azure/cognitiveservices-computervision';
+import { ApiKeyCredentials } from '@azure/ms-rest-js';
+
 /**
  * Script to load azure
  */
 
 export function getClient() {
-  const ComputerVisionClient = require('@azure/cognitiveservices-computervision').ComputerVisionClient;
-  const ApiKeyCredentials = require('@azure/ms-rest-js').ApiKeyCredentials;
-
   const key = process.env.SUBSCRIPTION_KEY;
   const endpoint = 'https://poggers-image-captioning-api.cognitiveservices.azure.com/';
 


### PR DESCRIPTION
You can't use `require` imports in browser. Use es imports next time